### PR TITLE
RT#75209: "use base Exporter" => "use Exporter 'import'"

### DIFF
--- a/lib/MooX/Types/MooseLike.pm
+++ b/lib/MooX/Types/MooseLike.pm
@@ -1,6 +1,6 @@
 use strictures 1;
 package MooX::Types::MooseLike;
-use base qw(Exporter);
+use Exporter 5.57 'import';
 
 sub register_types {
   my ($type_definitions, $into) = @_;
@@ -59,7 +59,7 @@ MooX::Types::MooseLike - some Moosish types and a typer builder
 	# but the API to build new types is Experimental
 	package MyApp::Types;
 	use MooX::Types::MooseLike::Base;
-	use base qw(Exporter);
+	use Exporter 'import';
 	our @EXPORT_OK = ();
 	my $defs = [{ 
 		name => 'MyType', 

--- a/lib/MooX/Types/MooseLike/Base.pm
+++ b/lib/MooX/Types/MooseLike/Base.pm
@@ -4,7 +4,7 @@ package MooX::Types::MooseLike::Base;
 use Scalar::Util qw(blessed);
 use List::Util;
 use MooX::Types::MooseLike;
-use base qw(Exporter);
+use Exporter 5.57 'import';
 our @EXPORT_OK = ();
 
 # These types act like those found in Moose::Util::TypeConstraints.

--- a/lib/MooX/Types/MooseLike/Numeric.pm
+++ b/lib/MooX/Types/MooseLike/Numeric.pm
@@ -2,7 +2,7 @@ use strictures 1;
 
 package MooX::Types::MooseLike::Numeric;
 use MooX::Types::MooseLike::Base;
-use base qw(Exporter);
+use Exporter 5.57 'import';
 our @EXPORT_OK = ();
 
 my $type_definitions = [


### PR DESCRIPTION
Fix for [RT#75209](https://rt.cpan.org/Public/Bug/Display.html?id=75209).

Avoid using 'base.pm' with no benefit.
Use Exporter as recommended in its documentation.
