### PR TITLE
nice stacktraces

### DIFF
--- a/lib/MooX/Types/MooseLike.pm
+++ b/lib/MooX/Types/MooseLike.pm
@@ -44,7 +44,9 @@ sub make_type {
   }
 
   my $isa = sub {
-    confess $type_definition->{message}->(@_) if not $full_test->(@_);
+    return if $full_test->(@_);
+    local $Carp::Internal{"MooX::Types::MooseLike"} = 1;
+    confess $type_definition->{message}->(@_);
   };
 
   my $full_name = $moose_namespace

--- a/t/basic.t
+++ b/t/basic.t
@@ -235,7 +235,7 @@ like(
 
 like(
     exception { MooX::Types::MooseLike::Test->new( an_undef => '' ) },
-    qr/is not undef.*\n.*MooX::Types::MooseLike::Test::new.*basic\.t/s,
+    qr/is not undef.*\n.*MooX::Types::MooseLike::Test::new.*basic\.t/,
     'error looks like useful stacktrace'
 );
 


### PR DESCRIPTION
Carp::Clan wasn't applicable here, since the stacktrace of a confess can't be filtered with it, only the croak can be filtered. However Carp has a way to filter the start of a trace, making it possible to strip unwanted frames from the start of the trace.
