### PR TITLE
Impoved parameterized type validation

### DIFF
--- a/lib/MooX/Types/MooseLike.pm
+++ b/lib/MooX/Types/MooseLike.pm
@@ -67,6 +67,7 @@ sub make_type {
 
       # If we have a parameterized type then we want to check its values
       if ( $_[0]
+        && ref($_[0]) eq 'ARRAY'
         && $_[0]->[0]
         && ref($_[0]->[0])
         && (ref($_[0]->[0]) eq 'CODE'))


### PR DESCRIPTION
Without a ref check on $_[0] errors like:

Can't use string ("MIME::Types") as an ARRAY ref while "strict refs" in use at
/home/mphillips/projects/MooX-Types-MooseLike/lib/MooX/Types/MooseLike.pm line
69, <DATA> line 998.

can occur if invalid data is passed (ie isa => ArrayRef('FooBar'))
