### PR TITLE
Configurable Parameterized Types

### DIFF
--- a/lib/MooX/Types/MooseLike.pm
+++ b/lib/MooX/Types/MooseLike.pm
@@ -76,14 +76,7 @@ sub make_type {
         my $parameterized_isa = sub {
           $isa->(@_);
 
-          # A dispatch table that gets the values for each parameterized type
-          my %parameter_values = (
-            ArrayRef  => sub { @{ $_[0] } },
-            HashRef   => sub { values %{ $_[0] } },
-            ScalarRef => sub { ${ $_[0] } },
-            Maybe     => sub { return if (not defined $_[0]); $_[0] },
-            );
-          my @values = $parameter_values{ $type_definition->{name} }->(@_);
+          my @values = $type_definition->{parameterizable}->(@_);
 
           # Run the type coderef on each value
           foreach my $value (@values) {
@@ -126,6 +119,15 @@ MooX::Types::MooseLike - some Moosish types and a type builder
       message => sub { "$_[0] is not the type we want!" }
     },
     {
+      name => 'Set_Object',
+      test => sub {
+         require Scalar::Util;
+         Scalar::Util::blessed($_[0]) && $_[0]->isa("Set::Object")
+      },
+      message => sub { "$_[0] is not a Set::Object!" }
+      parameterizable => sub { $_[0]->members },
+    },
+    {
       name => 'MyLengthTypeWithParam',
       test => sub {
         my ($value, $param) = @_;
@@ -150,9 +152,14 @@ MooX::Types::MooseLike - some Moosish types and a type builder
     );
 
     has string => (
+      is  => 'ro',
       isa => MyLengthTypeWithParam(25)
     );
 
+    has gadgets => (
+      is  => 'ro',
+      isa => Set_Object([MyType]),
+    );
 
 =head1 DESCRIPTION
 
@@ -171,6 +178,8 @@ mst - Matt S. Trout (cpan:MSTROUT) <mst@shadowcat.co.uk>
 Mithaldu - Christian Walde (cpan:MITHALDU) <walde.christian@googlemail.com>
 
 Matt Phillips (cpan:MATTP) <mattp@cpan.org>
+
+Arthur Axel fREW Schmidt (cpan:FREW) <frioux@gmail.com>
 
 =head1 COPYRIGHT
 

--- a/lib/MooX/Types/MooseLike/Base.pm
+++ b/lib/MooX/Types/MooseLike/Base.pm
@@ -76,21 +76,25 @@ my $type_definitions = [
     name    => 'Maybe',
     test    => sub { 1 },
     message => sub { 'Maybe only uses its parameterized type message' },
+    parameterizable => sub { return if (not defined $_[0]); $_[0] },
   },
   {
     name => 'ScalarRef',
     test => sub { ref($_[0]) eq 'SCALAR' },
     message => sub { "$_[0] is not an ScalarRef!" },
+    parameterizable => sub { ${ $_[0] } },
   },
   {
     name => 'ArrayRef',
     test => sub { ref($_[0]) eq 'ARRAY' },
     message => sub { "$_[0] is not an ArrayRef!" },
+    parameterizable => sub { @{ $_[0] } },
   },
   {
     name => 'HashRef',
     test => sub { ref($_[0]) eq 'HASH' },
     message => sub { "$_[0] is not a HashRef!" },
+    parameterizable => sub { values %{ $_[0] } },
   },
   {
     name => 'CodeRef',


### PR DESCRIPTION
So just like you can do ArrayRef [Int] this allows you to do Set_Object [Int].  For some reason in my test the latter requires parens though.
