### PR TITLE
depend on Moo >= 0.091009

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ use ExtUtils::MakeMaker;
 (do 'maint/Makefile.PL.include' or die $@) unless -f 'META.yml';
 
 my %RUN_DEPS = (
-  'Moo' => 0.091006,
+  'Moo' => 0.091009,
   'Module::Runtime' => 0.012,
 );
 my %BUILD_DEPS = (


### PR DESCRIPTION
Older Moo couldn't apply several roles in one `with` statement. It applied the first one and ignored the rest.
So `MooX::Types::MooseLike::Test` from `t/parameterized.t` didn't work as expected and 'consumer of a some roles' test failed on Moo=0.091007.
(Technically, `with` behavior changed in Moo 0.091008, but that release was broken anyway and didn't pass its own tests.)
