### PR TITLE
don't trigger bool overrides when checking for object instance type

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+    - don't trigger bool overrides when checking for object instance type
     - Make Moo a build dep. instead of run dep.
 
 0.24 - 2013-07-10

--- a/lib/MooX/Types/MooseLike/Base.pm
+++ b/lib/MooX/Types/MooseLike/Base.pm
@@ -211,7 +211,7 @@ sub blessed_type_definitions {## no critic qw(Subroutines::ProhibitExcessComplex
       name => 'InstanceOf',
       test => sub {
         my ($instance, @classes) = (shift, @_);
-        return if not $instance;
+        return if not defined $instance;
         return if not blessed($instance);
         my @missing_classes = grep { !$instance->isa($_) } @classes;
         return (scalar @missing_classes ? 0 : 1);

--- a/t/parameterized_with_string.t
+++ b/t/parameterized_with_string.t
@@ -1,4 +1,9 @@
 {
+  package NoBool;
+  use Moo;
+  use overload ('bool' => sub { die });
+}
+{
   package MooX::Types::MooseLike::Test::Role;
   use Role::Tiny;
   sub foo { 'ja' };
@@ -44,6 +49,10 @@
   has instance_of_A_and_B => (
     is  => 'ro',
     isa => InstanceOf['A', 'B'],
+    );
+  has instance_of_NoBool => (
+    is  => 'ro',
+    isa => InstanceOf['NoBool'],
     );
   has consumer_of => (
     is  => 'ro',
@@ -95,6 +104,7 @@ like(
   'a Foo instance is not an instance of IO::Handle'
   );
 ok(MooX::Types::MooseLike::Test->new(instance_of_A_and_B => B->new ), 'instance of A and B');
+ok(MooX::Types::MooseLike::Test->new(instance_of_NoBool => NoBool->new ), 'instance of NoBool');
 
 # ConsumerOf
 ok(MooX::Types::MooseLike::Test->new(consumer_of => MooX::Types::MooseLike::Test->new ), 'consumer of a some roles');


### PR DESCRIPTION
This commit has a fix and a test for objects that fail the InstanceOf check because their overridden bool behavior gets accidentally triggered. This is important when dealing with PDL objects.
