### PR TITLE
Update the required Moo version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,7 +8,7 @@ my %RUN_DEPS = (
   'Module::Runtime' => 0.012,
 );
 my %BUILD_DEPS = (
-  'Moo'         => 1.007000,
+  'Moo'         => 1.000007,
   'Test::More'  => 0.96,
   'Test::Fatal' => 0.003,
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,7 +8,7 @@ my %RUN_DEPS = (
   'Module::Runtime' => 0.012,
 );
 my %BUILD_DEPS = (
-  'Moo' => 0.091010,
+  'Moo'         => 1.007000,
   'Test::More'  => 0.96,
   'Test::Fatal' => 0.003,
 );


### PR DESCRIPTION
According to cpantestsers.org, version 0.091010 of Moo has a lot of issues with passing tests and thus can’t be successfully installed on some systems with some perl versions, and this in turn reflects MooX::Types::MooseLike:

https://rt.cpan.org/Public/Bug/Display.html?id=96307
http://www.cpantesters.org/cpan/report/d7f48dbe-2937-11e4-804f-f6ff4915a708

Setting Moo version to 1.000007 is likely to address these issues.